### PR TITLE
chore(ci): 更新CI工作流中的运行环境

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: Build
     env:
       BOOST_ROOT: ${{ github.workspace }}\librime\deps\boost-1.89.0


### PR DESCRIPTION
将runs-on从windows-latest更改为windows-2022以使用指定的Windows版本