### PR TITLE
feat(ci): 更新构建流程以从libximecore依赖中复制rime.dll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
   build:
     runs-on: windows-2022
     name: Build
-    env:
-      BOOST_ROOT: ${{ github.workspace }}\librime\deps\boost-1.89.0
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,45 +23,33 @@ jobs:
       - name: Init nested submodules
         run: git submodule update --init --recursive
 
-      - name: Cache librime build
-        id: cache-librime
-        uses: actions/cache@v4
-        with:
-          path: |
-            librime/dist
-            librime/deps/boost-*
-          key: librime-${{ hashFiles('librime/src/**', 'librime/CMakeLists.txt', 'librime/build.bat', 'librime/deps/**/CMakeLists.txt', 'crates/librime-sys/build.rs', 'plugins/librime-octagram/**', 'plugins/librime-lua/**') }}
-
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Install build tools
-        if: steps.cache-librime.outputs.cache-hit != 'true'
-        run: choco install aria2 7zip -y
-
-      - name: Build librime
-        if: steps.cache-librime.outputs.cache-hit != 'true'
-        shell: cmd
-        working-directory: librime
-        run: |
-          copy env.vs2022.bat env.bat
-          echo set ARCH=x64 >> env.bat
-          call install-boost.bat
-          if not exist "plugins\lua" xcopy /e /i /q "%CD%\..\plugins\librime-lua" "plugins\lua"
-          if not exist "plugins\octagram" xcopy /e /i /q "%CD%\..\plugins\librime-octagram" "plugins\octagram"
-          if not exist "plugins\lua\thirdparty\lua5.4\lua.h" (
-            if exist "plugins\lua\action-install.bat" (
-              pushd plugins\lua && call action-install.bat && popd
-            )
-          )
-          build.bat deps
-          build.bat librime shared
-          if not exist "%CD%\dist\lib\rime.dll" (echo ERROR: rime.dll not created && dir "%CD%\dist\lib" && exit /b 1)
 
       - uses: Swatinem/rust-cache@v2
 
       - name: Build release
         run: cargo build --release --quiet
+
+      - name: Copy rime.dll from libximecore git dep
+        shell: pwsh
+        run: |
+          $json = cargo metadata --format-version 1 | ConvertFrom-Json
+          $pkg = $json.packages | Where-Object { $_.name -eq 'librime-sys2' }
+          if (-not $pkg) {
+            Write-Error "librime-sys2 not found in cargo metadata"
+            exit 1
+          }
+          $manifestPath = $pkg.manifest_path
+          # manifest_path: <libximecore_root>/crates/librime-sys2/Cargo.toml
+          $libximecoreRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $manifestPath))
+          $rimeDll = Join-Path $libximecoreRoot "librime\dist\lib\rime.dll"
+          if (-not (Test-Path $rimeDll)) {
+            Write-Error "rime.dll not found at $rimeDll"
+            exit 1
+          }
+          Copy-Item $rimeDll "target\release\rime.dll" -Force
+          Write-Host "Copied rime.dll to target\release\"
 
       - name: Prepare config files
         shell: cmd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9014,7 +9014,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winxime-ipc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "interprocess",
  "serde",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "winxime-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "interprocess",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "winxime-setup"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "gpui 0.2.2 (git+https://github.com/zed-industries/zed?rev=53e4d34a71f61f13572919c04335e9da838623e6)",
  "gpui_platform",
@@ -9058,7 +9058,7 @@ dependencies = [
 
 [[package]]
 name = "winxime-tsf"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "librime",
@@ -9072,7 +9072,7 @@ dependencies = [
 
 [[package]]
 name = "winxime-tsf-register"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "windows 0.62.2",
  "windows-core 0.62.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Kor1 <kingzcheung@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/crates/winxime-server/wix/data.wxs
+++ b/crates/winxime-server/wix/data.wxs
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>
-        <DirectoryRef Id="DataFolder" />
+        <DirectoryRef Id="DataFolder">
+            <Directory Id="dirFBD3FB4F222246CC12450DCF8246437D" Name="build" />
+        </DirectoryRef>
     </Fragment>
     <Fragment>
         <ComponentGroup Id="DataFiles">
@@ -19,6 +21,9 @@
             </Component>
             <Component Id="cmpAFE55EF47E9E7846E6EA9AD6AE6D89F1" Directory="DataFolder" Guid="*">
                 <File Id="filAC56CAD55002C57BE7F387B7CE51EF35" KeyPath="yes" Source="$(var.DataDir)\essay.txt" />
+            </Component>
+            <Component Id="cmp75CC1348FEC509ACA9DCDD11BBFE1F6A" Directory="DataFolder" Guid="*">
+                <File Id="filB85E4E859947D28BCA44E0E72261F80C" KeyPath="yes" Source="$(var.DataDir)\installation.yaml" />
             </Component>
             <Component Id="cmpE0ABC2ED196421F03DD15019BAF86A58" Directory="DataFolder" Guid="*">
                 <File Id="filC2A8084974AEB5D7B3C96B6C375BDC37" KeyPath="yes" Source="$(var.DataDir)\luna_pinyin.dict.yaml" />
@@ -40,6 +45,9 @@
             </Component>
             <Component Id="cmpDF69A01DDAD3644061A97C62E354F9D6" Directory="DataFolder" Guid="*">
                 <File Id="fil8B03148D486F7393FC39628DFF6A60AA" KeyPath="yes" Source="$(var.DataDir)\symbols.yaml" />
+            </Component>
+            <Component Id="cmpEAA37E76E0B156B8546A7C2AA26A218D" Directory="DataFolder" Guid="*">
+                <File Id="fil69FA70141FB5716DDE8BCE2A16850FDA" KeyPath="yes" Source="$(var.DataDir)\user.yaml" />
             </Component>
             <Component Id="cmp633E272D4764678C0A6A0186548D88D7" Directory="DataFolder" Guid="*">
                 <File Id="filBB0C5C8DDB55BF3D9EB49625829D487B" KeyPath="yes" Source="$(var.DataDir)\wubi86.dict.yaml" />
@@ -70,6 +78,51 @@
             </Component>
             <Component Id="cmp88B70484D12F6102598DEC2201E15B38" Directory="DataFolder" Guid="*">
                 <File Id="fil76B09CF2F0329A2CC15527E6B87A55BE" KeyPath="yes" Source="$(var.DataDir)\xime.custom.yaml" />
+            </Component>
+            <Component Id="cmp4CBA29225ADD963EA104239325E14FDF" Directory="DataFolder" Guid="*">
+                <File Id="fil6B0AB6DE5E04A948D2E696221F8E1A27" KeyPath="yes" Source="$(var.DataDir)\xime.yaml" />
+            </Component>
+            <Component Id="cmpADA026A186118B5CD4909D6148335B7F" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="filB4EF5BFA20199F54BE4DD48F6BAA3BED" KeyPath="yes" Source="$(var.DataDir)\build\default.yaml" />
+            </Component>
+            <Component Id="cmp73195D67445774B902F7F61EF1DE4053" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil202E28E7967CF39EDF9F974042635B52" KeyPath="yes" Source="$(var.DataDir)\build\numbers.schema.yaml" />
+            </Component>
+            <Component Id="cmp042BC83967AD7514A3F9CE96A4AF3AA7" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil5E10A766A319CBC23452A86BE8311366" KeyPath="yes" Source="$(var.DataDir)\build\pinyin_simp.prism.bin" />
+            </Component>
+            <Component Id="cmp0A5969CEF88515CE9347688BA4779A09" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil46B6E0AB3721E56650B4A06EA0C90823" KeyPath="yes" Source="$(var.DataDir)\build\pinyin_simp.reverse.bin" />
+            </Component>
+            <Component Id="cmp28A8A7D556424485C94BD22ADA83E2B7" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="filC0615227D04EBF229A5C9F96D422B9DC" KeyPath="yes" Source="$(var.DataDir)\build\pinyin_simp.schema.yaml" />
+            </Component>
+            <Component Id="cmp761E45F6A604B3F63EA67C57E97C7A7B" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil88CF585FB468F57518CCACBCB40CB19F" KeyPath="yes" Source="$(var.DataDir)\build\pinyin_simp.table.bin" />
+            </Component>
+            <Component Id="cmpD2C0508534C4789326CAF1C45596664B" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil07617CACA96AC95E0D4A0745E15BC9D2" KeyPath="yes" Source="$(var.DataDir)\build\wubi86.prism.bin" />
+            </Component>
+            <Component Id="cmpE89747FC7CD79FEB542DF7D33F30F2EA" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil41A5D19B9983277EA42754CDA7D53CDD" KeyPath="yes" Source="$(var.DataDir)\build\wubi86.reverse.bin" />
+            </Component>
+            <Component Id="cmp6BBDB79F336FF24134D11C9A7E51CF73" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil72F627C40BFC8F3FC86AE2A5A98914FC" KeyPath="yes" Source="$(var.DataDir)\build\wubi86.schema.yaml" />
+            </Component>
+            <Component Id="cmp51F87E2010B970306F67FF435CB442F8" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="filD3499BF2B4F8C922135C95E918B6C59D" KeyPath="yes" Source="$(var.DataDir)\build\wubi86.table.bin" />
+            </Component>
+            <Component Id="cmp5214C4A4FFF0927F9095349557C8C936" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil73F104333870595764247257E1C2ECF5" KeyPath="yes" Source="$(var.DataDir)\build\wubi86_pinyin.schema.yaml" />
+            </Component>
+            <Component Id="cmp9A016076DE27A55E1C20EC03635941FC" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil548BFEC271D5F65074572BC8F29108F7" KeyPath="yes" Source="$(var.DataDir)\build\wubi86_trad.schema.yaml" />
+            </Component>
+            <Component Id="cmp3F7740B94E026365A9E64A861D387C6C" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil45D3ACFD13366704A5CF6AE84C808362" KeyPath="yes" Source="$(var.DataDir)\build\wubi86_trad_pinyin.schema.yaml" />
+            </Component>
+            <Component Id="cmp75CC1C1FA0FE7AF71BC284F1F4D6F603" Directory="dirFBD3FB4F222246CC12450DCF8246437D" Guid="*">
+                <File Id="fil5F8421AB47F62BDF6FEB946B522C47E3" KeyPath="yes" Source="$(var.DataDir)\build\xime.yaml" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/msi-build.ps1
+++ b/msi-build.ps1
@@ -9,6 +9,23 @@ $ErrorActionPreference = "Stop"
 # Add WiX v3.14 to PATH
 $env:PATH += ";C:\Program Files (x86)\WiX Toolset v3.14\bin"
 
+function Find-LibrimeRoot {
+    $json = cargo metadata --format-version 1 | ConvertFrom-Json
+    $pkg = $json.packages | Where-Object { $_.name -eq 'librime-sys2' }
+    if (-not $pkg) {
+        Write-Error "librime-sys2 not found in cargo metadata"
+        exit 1
+    }
+    $manifestPath = $pkg.manifest_path
+    $libximecoreRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $manifestPath))
+    $librimeRoot = Join-Path $libximecoreRoot "librime"
+    if (-not (Test-Path $librimeRoot)) {
+        Write-Host "librime directory not found at $librimeRoot"
+        return $null
+    }
+    return $librimeRoot
+}
+
 # Auto-detect version from Cargo.toml
 if ($Version -eq "") {
     $cargoTomlContent = Get-Content "Cargo.toml" -Raw
@@ -29,6 +46,17 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
+# 1.5. Copy rime.dll from libximecore git dep to target\release
+Write-Host "Step 1.5: Copying rime.dll..." -ForegroundColor Yellow
+$librimeRoot = Find-LibrimeRoot
+$rimeDll = Join-Path $librimeRoot "dist\lib\rime.dll"
+if (Test-Path $rimeDll) {
+    Copy-Item $rimeDll "target\release\rime.dll" -Force
+    Write-Host "  rime.dll copied"
+} else {
+    Write-Warning "rime.dll not found at $rimeDll"
+}
+
 # 2. Copy data files
 Write-Host "Step 2: Copying data files..." -ForegroundColor Yellow
 if (Test-Path "target\release\data") {
@@ -36,7 +64,13 @@ if (Test-Path "target\release\data") {
 }
 New-Item "target\release\data" -ItemType Directory -Force | Out-Null
 
-Copy-Item "librime\data\minimal\*" "target\release\data" -Recurse -Force
+$librimeRoot = Find-LibrimeRoot
+$rimeDataDir = Join-Path $librimeRoot "data\minimal"
+if (Test-Path $rimeDataDir) {
+    Copy-Item "$rimeDataDir\*" "target\release\data" -Recurse -Force
+} else {
+    Write-Warning "rime data not found at $rimeDataDir, skipping"
+}
 
 $files = Get-ChildItem -Path "rime-wubi" -Recurse -File | Where-Object {
     $dir = $_.DirectoryName


### PR DESCRIPTION
- 移除BOOST_ROOT环境变量设置
- 删除librime构建缓存相关步骤
- 添加PowerShell脚本从libximecore git依赖中查找并复制rime.dll到目标目录
- 简化CI工作流，移除复杂的librime构建过程

BREAKING CHANGE: 构建流程不再本地构建librime，而是从git依赖获取预构建的库文件